### PR TITLE
Add common driver path as recommended from kernel 5.18

### DIFF
--- a/lgbatterylimit.sh
+++ b/lgbatterylimit.sh
@@ -1,4 +1,26 @@
-DRIVER="/sys/devices/platform/lg-laptop/battery_care_limit"
+DRIVER="/sys/class/power_supply/CMB0/charge_control_end_threshold"
+
+OLD_DRIVER="/sys/devices/platform/lg-laptop/battery_care_limit"
+
+# Lets check the kernel version
+# https://github.com/torvalds/linux/commit/07f5ed0eee011f2b76ee01a4939f3ff1d34ac5e3
+function driver_path_check() {
+  CURRENT_KERNEL_VERSION=$(uname --kernel-release | cut --delimiter="." --fields=1-2)
+  CURRENT_KERNEL_MAJOR_VERSION=$(echo "${CURRENT_KERNEL_VERSION}" | cut --delimiter="." --fields=1)
+  CURRENT_KERNEL_MINOR_VERSION=$(echo "${CURRENT_KERNEL_VERSION}" | cut --delimiter="." --fields=2)
+  if [ "${CURRENT_KERNEL_MAJOR_VERSION}" -lt "5" ]; then
+    DRIVER=$OLD_DRIVER
+  fi
+
+  if [ "${CURRENT_KERNEL_MAJOR_VERSION}" == "5" ]; then
+    if [ "${CURRENT_KERNEL_MINOR_VERSION}" -lt "18" ]; then
+      DRIVER=$OLD_DRIVER
+    fi
+  fi
+}
+
+driver_path_check
+
 if [ ! -f $DRIVER ]; then
   echo "LG driver file not found"
   exit -1


### PR DESCRIPTION
As stated in [this commit](https://github.com/torvalds/linux/commit/07f5ed0eee011f2b76ee01a4939f3ff1d34ac5e3), setting of battery charge limit now moved to common location at **/sys/class/power_supply/CMB0/charge_control_end_threshold** from kernel 5.18